### PR TITLE
Issue-7: Add Load metrics and relevant tests.

### DIFF
--- a/sunsynk/client.py
+++ b/sunsynk/client.py
@@ -10,6 +10,7 @@ from sunsynk.battery import Battery
 from sunsynk.grid import Grid
 from sunsynk.input import Input
 from sunsynk.inverter import Inverter
+from sunsynk.load import Load
 from sunsynk.output import Output
 from sunsynk.plant import Plant
 
@@ -74,6 +75,11 @@ class SunsynkClient:
         resp = await self.__get(f'api/v1/inverter/grid/{inverter_sn}/realtime?sn={inverter_sn}')
         body = await resp.json()
         return Grid(body['data'])
+
+    async def get_inverter_realtime_load(self, inverter_sn: str) -> Load:
+        resp = await self.__get(f'api/v1/inverter/load/{inverter_sn}/realtime?sn={inverter_sn}')
+        body = await resp.json()
+        return Load(body['data'])
 
     async def get_inverter_realtime_battery(self, inverter_sn: str) -> Battery:
         resp = await self.__get(f'api/v1/inverter/battery/{inverter_sn}/realtime?sn={inverter_sn}&lan')

--- a/sunsynk/load.py
+++ b/sunsynk/load.py
@@ -1,0 +1,31 @@
+from sunsynk.resource import Resource
+from sunsynk.vip import Vip
+
+
+class Load(Resource):
+    def __init__(self, data):
+        self.total_used = data['totalUsed']
+        self.daily_used = data['dailyUsed']
+        self.vip = [Vip(vip_data) for vip_data in data.get('vip', [])]
+        self.total_power = data['totalPower']
+        self.smart_load_status = data['smartLoadStatus']
+        self.load_fac = data['loadFac']
+        self.ups_power_l1 = data['upsPowerL1']
+        self.ups_power_l2 = data['upsPowerL2']
+        self.ups_power_l3 = data['upsPowerL3']
+        self.ups_power_total = data['upsPowerTotal']
+
+    def get_voltage(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].voltage)
+
+    def get_current(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].current)
+
+    def get_power(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].power)

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -26,6 +26,7 @@ class MockApiServer:
         self.app.router.add_get('/api/v1/inverter/battery/1029384756/realtime', self.get_inverter_realtime_battery)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/input', self.get_inverter_realtime_input)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/output', self.get_inverter_realtime_output)
+        self.app.router.add_get('/api/v1/inverter/load/1029384756/realtime', self.get_inverter_realtime_load)
 
     async def client(self, username='myuser'):
         client = await self.aiohttp_client(self.app)
@@ -301,6 +302,35 @@ class MockApiServer:
                 "pInv": 9,
                 "pac": -50,
                 "fac": 50.0
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_inverter_realtime_load(self, request):
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "totalUsed": 3133.10,
+                "dailyUsed": 34.70,
+                "vip": [
+                    {
+                        "volt": "246.6",
+                        "current": "0.0",
+                        "power": 3427
+                    }
+                ],
+                "totalPower": 3427,
+                "smartLoadStatus": -1,
+                "loadFac": 50.01,
+                "upsPowerL1": 5.0,
+                "upsPowerL2": 0.0,
+                "upsPowerL3": 0.0,
+                "upsPowerTotal": 5.0
             },
             "success": True
         }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,3 +85,31 @@ async def test_get_inverter_realtime_battery(aiohttp_client):
     assert battery.get_power() == -18
     assert battery.get_current() == -0.4
     assert battery.get_voltage() == 53.3
+
+
+@pytest.mark.asyncio
+async def test_get_inverter_realtime_load(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    inverters = await client.get_inverters()
+    load = await client.get_inverter_realtime_load(inverters[0].sn)
+
+    assert load.total_used == 3133.10
+    assert load.daily_used == 34.70
+    assert load.total_power == 3427
+    assert load.smart_load_status == -1
+    assert load.load_fac == 50.01
+    assert load.ups_power_l1 == 5.0
+    assert load.ups_power_l2 == 0.0
+    assert load.ups_power_l3 == 0.0
+    assert load.ups_power_total == 5.0
+
+    assert load.get_voltage() == 246.6
+    assert load.get_current() == 0.0
+    assert load.get_power() == 3427.0
+
+    load.vip = []
+    assert load.get_voltage() is None
+    assert load.get_current() is None
+    assert load.get_power() is None


### PR DESCRIPTION
# Pull Request: Issue-7: Add Load metrics and relevant tests

## Description
This pull request adds support for retrieving and parsing real-time load/UPS metrics from the Sunsynk inverter API.

It implements a new `Load` resource class that wraps all the load-related attributes returned by the `/api/v1/inverter/load/{sn}/realtime` endpoint (such as total and daily energy used, phase VIP status, smart load status, load frequency, and UPS phase/total powers).

### Key Features
* **New Resource Class**: Created [load.py](file:///home/ben/dev/sunsynk-api-client/sunsynk/load.py) representing the `Load` data model with properties matching the API payload structure.
* **Client Method**: Integrated `get_inverter_realtime_load(inverter_sn)` into the `SunsynkClient` class in [client.py](file:///home/ben/dev/sunsynk-api-client/sunsynk/client.py).
* **Mock Endpoint**: Expanded [mock_api_server.py](file:///home/ben/dev/sunsynk-api-client/tests/mock_api_server.py) to return a sample load metrics payload.
* **Unit Tests**: Added robust coverage in [test_client.py](file:///home/ben/dev/sunsynk-api-client/tests/test_client.py) asserting correct parsing of properties, as well as handling of edge cases (e.g. empty phase details).

---

## Technical Details

### API Payload Schema Mapped:
```json
{
    "totalUsed": 3133.10,
    "dailyUsed": 34.70,
    "vip": [
        {
            "volt": "246.6",
            "current": "0.0",
            "power": 3427
        }
    ],
    "totalPower": 3427,
    "smartLoadStatus": -1,
    "loadFac": 50.01,
    "upsPowerL1": 5.0,
    "upsPowerL2": 0.0,
    "upsPowerL3": 0.0,
    "upsPowerTotal": 5.0
}
```

### Properties in `Load` Class:
* `total_used`
* `daily_used`
* `vip` (list of `Vip` instances)
* `total_power`
* `smart_load_status`
* `load_fac`
* `ups_power_l1` / `ups_power_l2` / `ups_power_l3` / `ups_power_total`

---

## Verification Results
All tests passed with 100% code coverage on `sunsynk/load.py`:
```bash
tests/test_client.py .........                                           [100%]
---------------------------------------------
sunsynk/load.py              26      0   100%
---------------------------------------------
TOTAL                       354     46    87%
============================== 9 passed in 0.45s ===============================
```
