### PR TITLE
Implement Weather API and Plant Coordinate Retrieval

### DIFF
--- a/sunsynk/client.py
+++ b/sunsynk/client.py
@@ -13,6 +13,8 @@ from sunsynk.inverter import Inverter
 from sunsynk.load import Load
 from sunsynk.output import Output
 from sunsynk.plant import Plant
+from sunsynk.weather import Weather
+
 
 
 class InvalidCredentialsException(Exception):
@@ -53,6 +55,20 @@ class SunsynkClient:
         body = await resp.json()
         plants = body['data']['infos']
         return [Plant(data) for data in plants]
+
+    async def get_plant(self, plant_id: int) -> Plant:
+        resp = await self.__get(f'api/v1/plant/{plant_id}?lan=en&id={plant_id}')
+        body = await resp.json()
+        return Plant(body['data'])
+
+    async def get_weather(self, lon_lat: str, date: str = None, lan: str = 'en') -> Weather:
+        if date is None:
+            import datetime
+            date = datetime.date.today().isoformat()
+        resp = await self.__get(f'api/v1/weather?lan={lan}&date={date}&lonLat={lon_lat}')
+        body = await resp.json()
+        return Weather(body['data'])
+
 
     async def get_inverters(self) -> list[Inverter]:
         resp = await self.__get('api/v1/inverters?page=1&limit=10&total=0&status=-1&sn=&plantId=&type=-2&softVer=&' \

--- a/sunsynk/client.py
+++ b/sunsynk/client.py
@@ -10,6 +10,7 @@ from sunsynk.battery import Battery
 from sunsynk.grid import Grid
 from sunsynk.input import Input
 from sunsynk.inverter import Inverter
+from sunsynk.load import Load
 from sunsynk.output import Output
 from sunsynk.plant import Plant
 
@@ -74,6 +75,11 @@ class SunsynkClient:
         resp = await self.__get(f'api/v1/inverter/grid/{inverter_sn}/realtime?sn={inverter_sn}')
         body = await resp.json()
         return Grid(body['data'])
+
+    async def get_inverter_realtime_load(self, inverter_sn: str) -> Load:
+        resp = await self.__get(f'api/v1/inverter/load/{inverter_sn}/realtime?sn={inverter_sn}')
+        body = await resp.json()
+        return Load(body['data'])
 
     async def get_inverter_realtime_battery(self, inverter_sn: str) -> Battery:
         resp = await self.__get(f'api/v1/inverter/battery/{inverter_sn}/realtime?sn={inverter_sn}&lan')

--- a/sunsynk/load.py
+++ b/sunsynk/load.py
@@ -1,0 +1,31 @@
+from sunsynk.resource import Resource
+from sunsynk.vip import Vip
+
+
+class Load(Resource):
+    def __init__(self, data):
+        self.total_used = data['totalUsed']
+        self.daily_used = data['dailyUsed']
+        self.vip = [Vip(vip_data) for vip_data in data.get('vip', [])]
+        self.total_power = data['totalPower']
+        self.smart_load_status = data['smartLoadStatus']
+        self.load_fac = data['loadFac']
+        self.ups_power_l1 = data['upsPowerL1']
+        self.ups_power_l2 = data['upsPowerL2']
+        self.ups_power_l3 = data['upsPowerL3']
+        self.ups_power_total = data['upsPowerTotal']
+
+    def get_voltage(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].voltage)
+
+    def get_current(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].current)
+
+    def get_power(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].power)

--- a/sunsynk/plant.py
+++ b/sunsynk/plant.py
@@ -7,17 +7,41 @@ class Plant(Resource):
     def __init__(self, data):
         self.id = data['id']
         self.name = data['name']
-        self.thumb_url = data['thumbUrl']
-        self.status = data['status']
-        self.address = data['address']
-        self.pac = data['pac']
-        self.efficiency = data['efficiency']
-        self.generation_today = data['etoday']
-        self.generation_total = data['etotal']
-        self.updated_at = datetime.datetime.strptime(data['updateAt'], "%Y-%m-%dT%H:%M:%SZ")
-        self.created_at = datetime.datetime.fromisoformat(data['createAt'])
-        self.type = data['type']
-        self.master_id = data['masterId']
-        self.share = data['share']
-        self.plant_permissions = data['plantPermission']
-        self.exist_camera = data['existCamera']
+        self.thumb_url = data.get('thumbUrl')
+        self.status = data.get('status')
+        self.address = data.get('address')
+        
+        realtime = data.get('realtime') or {}
+        self.pac = data.get('pac') if 'pac' in data else realtime.get('pac')
+        self.efficiency = data.get('efficiency') if 'efficiency' in data else realtime.get('efficiency')
+        self.generation_today = data.get('etoday') if 'etoday' in data else realtime.get('etoday')
+        self.generation_total = data.get('etotal') if 'etotal' in data else realtime.get('etotal')
+        
+        update_at_str = data.get('updateAt') or realtime.get('updateAt')
+        if update_at_str:
+            self.updated_at = datetime.datetime.strptime(update_at_str, "%Y-%m-%dT%H:%M:%SZ")
+        else:
+            self.updated_at = None
+            
+        create_at_str = data.get('createAt')
+        if create_at_str:
+            self.created_at = datetime.datetime.fromisoformat(create_at_str)
+        else:
+            self.created_at = None
+            
+        self.type = data.get('type')
+        
+        if 'masterId' in data:
+            self.master_id = data['masterId']
+        elif 'master' in data and data['master']:
+            self.master_id = data['master'].get('id')
+        else:
+            self.master_id = None
+            
+        self.share = data.get('share')
+        self.plant_permissions = data.get('plantPermission')
+        self.exist_camera = data.get('existCamera')
+        
+        self.lon = data.get('lon')
+        self.lat = data.get('lat')
+

--- a/sunsynk/weather.py
+++ b/sunsynk/weather.py
@@ -1,0 +1,40 @@
+from sunsynk.resource import Resource
+
+
+class Weather(Resource):
+    def __init__(self, data):
+        curr_wea = data.get('currWea') or {}
+        self.description = curr_wea.get('desc')
+        self.current_temp = curr_wea.get('currTemp')
+        self.wind_speed = curr_wea.get('windSpeed')
+        self.wind_direction = curr_wea.get('windDirection')
+        self.sunrise = curr_wea.get('sunrise')
+        self.sunset = curr_wea.get('sunset')
+        self.icon_url = curr_wea.get('iconUrl')
+        self.temp_min_c = curr_wea.get('tempMinC')
+        self.temp_max_c = curr_wea.get('tempMaxC')
+
+    def get_current_temp(self) -> float | None:
+        if self.current_temp is None:
+            return None
+        return float(self.current_temp)
+
+    def get_wind_speed(self) -> float | None:
+        if self.wind_speed is None:
+            return None
+        return float(self.wind_speed)
+
+    def get_wind_direction(self) -> int | None:
+        if self.wind_direction is None:
+            return None
+        return int(self.wind_direction)
+
+    def get_temp_min_c(self) -> float | None:
+        if self.temp_min_c is None:
+            return None
+        return float(self.temp_min_c)
+
+    def get_temp_max_c(self) -> float | None:
+        if self.temp_max_c is None:
+            return None
+        return float(self.temp_max_c)

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -27,6 +27,9 @@ class MockApiServer:
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/input', self.get_inverter_realtime_input)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/output', self.get_inverter_realtime_output)
         self.app.router.add_get('/api/v1/inverter/load/1029384756/realtime', self.get_inverter_realtime_load)
+        self.app.router.add_get('/api/v1/plant/12345', self.get_plant)
+        self.app.router.add_get('/api/v1/weather', self.get_weather)
+
 
     async def client(self, username='myuser'):
         client = await self.aiohttp_client(self.app)
@@ -338,5 +341,113 @@ class MockApiServer:
             'Content-Type': 'application/json'
         }
         return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_plant(self, request):
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "id": 12345,
+                "name": "John Smith",
+                "totalPower": 3.68,
+                "thumbUrl": "https://",
+                "joinDate": "2025-02-20T00:00:00Z",
+                "type": 2,
+                "status": 1,
+                "charges": [
+                    {
+                        "id": 112001545,
+                        "startRange": "00:00",
+                        "endRange": "24:00",
+                        "price": 0.15,
+                        "type": 1,
+                        "stationId": 12345,
+                        "createAt": "2026-03-30T13:13:36Z",
+                        "status": None
+                    }
+                ],
+                "products": None,
+                "lon": -0.724613,
+                "lat": 51.322984,
+                "address": "123 Fake Street",
+                "master": {
+                    "id": 54321,
+                    "nickname": "master@gmail.com",
+                    "mobile": None
+                },
+                "currency": {
+                    "id": 366,
+                    "code": "GBP",
+                    "text": "£"
+                },
+                "timezone": {
+                    "id": 234,
+                    "code": "Europe/London",
+                    "text": "(UTC+00:00)Dublin,Edinburgh,Lisbon,London"
+                },
+                "realtime": {
+                    "pac": 2484,
+                    "efficiency": 0.000,
+                    "etoday": 9.00,
+                    "emonth": 119.40,
+                    "eyear": 1776.50,
+                    "etotal": 5622.30,
+                    "totalPower": 3.68,
+                    "currency": {
+                        "id": 366,
+                        "code": "GBP",
+                        "text": "£"
+                    },
+                    "invest": 8320.00,
+                    "income": 1.3500,
+                    "updateAt": "2026-07-07T12:02:52Z"
+                },
+                "createAt": "2022-10-03T15:39:21.000+00:00",
+                "phone": "01257443377",
+                "email": "",
+                "installer": "",
+                "principal": "Contact Solar",
+                "plantPermission": [
+                    "station.share.cancle"
+                ],
+                "fluxProducts": None,
+                "productWarrantyRegistered": 0,
+                "ctEnable": 1,
+                "invest": 8320.00,
+                "epexProduct": None
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_weather(self, request):
+        lon_lat = request.query.get('lonLat')
+        assert lon_lat == '51.322984,-0.724613'
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "currWea": {
+                    "desc": "broken clouds",
+                    "currTemp": "20.6",
+                    "windSpeed": "3.9",
+                    "windDirection": "292",
+                    "sunrise": "04:55",
+                    "sunset": "21:19",
+                    "iconUrl": "https://sunsynk-s3.s3.eu-west-2.amazonaws.com/weather/openweather/04d.png",
+                    "tempMinC": "19.7",
+                    "tempMaxC": "21.8"
+                }
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
 
 

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -26,6 +26,7 @@ class MockApiServer:
         self.app.router.add_get('/api/v1/inverter/battery/1029384756/realtime', self.get_inverter_realtime_battery)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/input', self.get_inverter_realtime_input)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/output', self.get_inverter_realtime_output)
+        self.app.router.add_get('/api/v1/inverter/load/1029384756/realtime', self.get_inverter_realtime_load)
 
     async def client(self, username='myuser'):
         client = await self.aiohttp_client(self.app)
@@ -301,6 +302,35 @@ class MockApiServer:
                 "pInv": 9,
                 "pac": -50,
                 "fac": 50.0
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_inverter_realtime_load(self, request):
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "totalUsed": 3133.10,
+                "dailyUsed": 34.70,
+                "vip": [
+                    {
+                        "volt": "246.6",
+                        "current": "0.0",
+                        "power": 3427
+                    }
+                ],
+                "totalPower": 3427,
+                "smartLoadStatus": -1,
+                "loadFac": 50.01,
+                "upsPowerL1": 5.0,
+                "upsPowerL2": 0.0,
+                "upsPowerL3": 0.0,
+                "upsPowerTotal": 5.0
             },
             "success": True
         }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,3 +85,31 @@ async def test_get_inverter_realtime_battery(aiohttp_client):
     assert battery.get_power() == -18
     assert battery.get_current() == -0.4
     assert battery.get_voltage() == 53.3
+
+
+@pytest.mark.asyncio
+async def test_get_inverter_realtime_load(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    inverters = await client.get_inverters()
+    load = await client.get_inverter_realtime_load(inverters[0].sn)
+
+    assert load.total_used == 3133.10
+    assert load.daily_used == 34.70
+    assert load.total_power == 3427
+    assert load.smart_load_status == -1
+    assert load.load_fac == 50.01
+    assert load.ups_power_l1 == 5.0
+    assert load.ups_power_l2 == 0.0
+    assert load.ups_power_l3 == 0.0
+    assert load.ups_power_total == 5.0
+
+    assert load.get_voltage() == 246.6
+    assert load.get_current() == 0.0
+    assert load.get_power() == 3427.0
+
+    load.vip = []
+    assert load.get_voltage() is None
+    assert load.get_current() is None
+    assert load.get_power() is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,9 @@
 import pytest
 
 from sunsynk.client import SunsynkClient, InvalidCredentialsException
+from sunsynk.weather import Weather
 from tests.mock_api_server import MockApiServer
+
 
 
 @pytest.mark.asyncio
@@ -113,3 +115,44 @@ async def test_get_inverter_realtime_load(aiohttp_client):
     assert load.get_voltage() is None
     assert load.get_current() is None
     assert load.get_power() is None
+
+
+@pytest.mark.asyncio
+async def test_get_plant(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    plant = await client.get_plant(12345)
+
+    assert plant.id == 12345
+    assert plant.name == 'John Smith'
+    assert plant.lon == -0.724613
+    assert plant.lat == 51.322984
+    assert plant.generation_today == 9.00
+    assert plant.generation_total == 5622.30
+    assert plant.pac == 2484
+    assert plant.master_id == 54321
+
+
+@pytest.mark.asyncio
+async def test_get_weather(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    plant = await client.get_plant(12345)
+    lon_lat = f"{plant.lat},{plant.lon}"
+    assert lon_lat == "51.322984,-0.724613"
+
+    weather = await client.get_weather(lon_lat, date="2026-07-07")
+
+    assert isinstance(weather, Weather)
+    assert weather.description == "broken clouds"
+    assert weather.get_current_temp() == 20.6
+    assert weather.get_wind_speed() == 3.9
+    assert weather.get_wind_direction() == 292
+    assert weather.sunrise == "04:55"
+    assert weather.sunset == "21:19"
+    assert weather.icon_url == "https://sunsynk-s3.s3.eu-west-2.amazonaws.com/weather/openweather/04d.png"
+    assert weather.get_temp_min_c() == 19.7
+    assert weather.get_temp_max_c() == 21.8
+


### PR DESCRIPTION
## Description
This pull request adds support for the Sunsynk Weather API (`/api/v1/weather`) to retrieve current weather conditions based on coordinate locations. In order to dynamically fetch coordinates, the `Plant` resource has also been updated to retrieve latitude (`lat`) and longitude (`lon`) from the detailed plant endpoint (`/api/v1/plant/{id}`).

## Key Changes

### API Client (`sunsynk/client.py`)
- Added `get_plant(self, plant_id: int) -> Plant` to query detailed plant data.
- Added `get_weather(self, lon_lat: str, date: str = None, lan: str = 'en') -> Weather` to query the weather. If `date` is omitted, it defaults to today's date (`YYYY-MM-DD`).

### Models & Resources
- **`sunsynk/weather.py`**: Added the `Weather` resource class containing attributes mapping current weather metrics (`description`, `current_temp`, `wind_speed`, `wind_direction`, `sunrise`, `sunset`, `icon_url`, `temp_min_c`, `temp_max_c`) and getter methods to parse numeric fields.
- **`sunsynk/plant.py`**: Updated `Plant`'s constructor to support both the summary format (from the plant list API) and detailed format (from the single plant API), parsing `lat` and `lon` fields.

### Testing & Mock Server (`tests/`)
- **`tests/mock_api_server.py`**: Added mock endpoints for `/api/v1/plant/{id}` and `/api/v1/weather`.
- **`tests/test_client.py`**: Added unit tests `test_get_plant` and `test_get_weather` verifying the parsing and correctness of the retrieved fields.

## Verification
Ran the unit tests with code coverage:
```bash
./run-tests.sh
```
All 11 tests passed successfully:
```
tests/test_client.py ...........                                         [100%]
============================== 11 passed in 0.57s ===============================
```