### PR TITLE
Add Weather API and plant coordinate retrieval (supersedes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,25 @@ An API client library for reading data from the Sunsynk API that is used by the 
         print('Done!')
     
     asyncio.run(main())
+
+
+## Load, Plant Details and Weather
+
+In addition to the inverter realtime data shown above, the client can also read
+the realtime load/UPS metrics, full plant details (including coordinates), and
+the weather for a plant's location:
+
+    async with SunsynkClient(sunsynk_username, sunsynk_password) as client:
+        inverters = await client.get_inverters()
+        load = await client.get_inverter_realtime_load(inverters[0].sn)
+        print(f"Load is drawing {load.get_power()}W ({load.daily_used} kWh used today)")
+
+        # get_plant returns the full plant detail, including lon/lat coordinates
+        plant = await client.get_plant(inverters[0].plant.id)
+
+        # The Sunsynk weather endpoint expects the coordinates as "lat,lon"
+        weather = await client.get_weather(f"{plant.lat},{plant.lon}")
+        print(f"It is currently {weather.get_current_temp()}C and {weather.description}")
+
+`get_weather` defaults to today's date; pass `date="YYYY-MM-DD"` to request a
+specific day.

--- a/sunsynk/client.py
+++ b/sunsynk/client.py
@@ -13,6 +13,8 @@ from sunsynk.inverter import Inverter
 from sunsynk.load import Load
 from sunsynk.output import Output
 from sunsynk.plant import Plant
+from sunsynk.weather import Weather
+
 
 
 class InvalidCredentialsException(Exception):
@@ -53,6 +55,20 @@ class SunsynkClient:
         body = await resp.json()
         plants = body['data']['infos']
         return [Plant(data) for data in plants]
+
+    async def get_plant(self, plant_id: int) -> Plant:
+        resp = await self.__get(f'api/v1/plant/{plant_id}?lan=en&id={plant_id}')
+        body = await resp.json()
+        return Plant(body['data'])
+
+    async def get_weather(self, lon_lat: str, date: str = None, lan: str = 'en') -> Weather:
+        if date is None:
+            import datetime
+            date = datetime.date.today().isoformat()
+        resp = await self.__get(f'api/v1/weather?lan={lan}&date={date}&lonLat={lon_lat}')
+        body = await resp.json()
+        return Weather(body['data'])
+
 
     async def get_inverters(self) -> list[Inverter]:
         resp = await self.__get('api/v1/inverters?page=1&limit=10&total=0&status=-1&sn=&plantId=&type=-2&softVer=&' \

--- a/sunsynk/client.py
+++ b/sunsynk/client.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import hashlib
 import time
 
@@ -14,7 +15,6 @@ from sunsynk.load import Load
 from sunsynk.output import Output
 from sunsynk.plant import Plant
 from sunsynk.weather import Weather
-
 
 
 class InvalidCredentialsException(Exception):
@@ -63,12 +63,10 @@ class SunsynkClient:
 
     async def get_weather(self, lon_lat: str, date: str = None, lan: str = 'en') -> Weather:
         if date is None:
-            import datetime
             date = datetime.date.today().isoformat()
         resp = await self.__get(f'api/v1/weather?lan={lan}&date={date}&lonLat={lon_lat}')
         body = await resp.json()
         return Weather(body['data'])
-
 
     async def get_inverters(self) -> list[Inverter]:
         resp = await self.__get('api/v1/inverters?page=1&limit=10&total=0&status=-1&sn=&plantId=&type=-2&softVer=&' \

--- a/sunsynk/grid.py
+++ b/sunsynk/grid.py
@@ -1,8 +1,8 @@
-from sunsynk.resource import Resource
 from sunsynk.vip import Vip
+from sunsynk.vip_resource import VipResource
 
 
-class Grid(Resource):
+class Grid(VipResource):
     def __init__(self, data):
         self.vip = [Vip(vip_data) for vip_data in data['vip']]
         self.pac = data['pac']
@@ -17,18 +17,3 @@ class Grid(Resource):
         self.total_export = data['etotalTo']
         self.limiter_power_arr = data['limiterPowerArr']
         self.limiter_total_power = data['limiterTotalPower']
-
-    def get_voltage(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].voltage)
-
-    def get_current(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].current)
-
-    def get_power(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].power)

--- a/sunsynk/load.py
+++ b/sunsynk/load.py
@@ -1,8 +1,8 @@
-from sunsynk.resource import Resource
 from sunsynk.vip import Vip
+from sunsynk.vip_resource import VipResource
 
 
-class Load(Resource):
+class Load(VipResource):
     def __init__(self, data):
         self.total_used = data['totalUsed']
         self.daily_used = data['dailyUsed']
@@ -14,18 +14,3 @@ class Load(Resource):
         self.ups_power_l2 = data['upsPowerL2']
         self.ups_power_l3 = data['upsPowerL3']
         self.ups_power_total = data['upsPowerTotal']
-
-    def get_voltage(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].voltage)
-
-    def get_current(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].current)
-
-    def get_power(self) -> float | None:
-        if len(self.vip) == 0:
-            return None
-        return float(self.vip[0].power)

--- a/sunsynk/plant.py
+++ b/sunsynk/plant.py
@@ -7,17 +7,41 @@ class Plant(Resource):
     def __init__(self, data):
         self.id = data['id']
         self.name = data['name']
-        self.thumb_url = data['thumbUrl']
-        self.status = data['status']
-        self.address = data['address']
-        self.pac = data['pac']
-        self.efficiency = data['efficiency']
-        self.generation_today = data['etoday']
-        self.generation_total = data['etotal']
-        self.updated_at = datetime.datetime.strptime(data['updateAt'], "%Y-%m-%dT%H:%M:%SZ")
-        self.created_at = datetime.datetime.fromisoformat(data['createAt'])
-        self.type = data['type']
-        self.master_id = data['masterId']
-        self.share = data['share']
-        self.plant_permissions = data['plantPermission']
-        self.exist_camera = data['existCamera']
+        self.thumb_url = data.get('thumbUrl')
+        self.status = data.get('status')
+        self.address = data.get('address')
+        
+        realtime = data.get('realtime') or {}
+        self.pac = data.get('pac') if 'pac' in data else realtime.get('pac')
+        self.efficiency = data.get('efficiency') if 'efficiency' in data else realtime.get('efficiency')
+        self.generation_today = data.get('etoday') if 'etoday' in data else realtime.get('etoday')
+        self.generation_total = data.get('etotal') if 'etotal' in data else realtime.get('etotal')
+        
+        update_at_str = data.get('updateAt') or realtime.get('updateAt')
+        if update_at_str:
+            self.updated_at = datetime.datetime.strptime(update_at_str, "%Y-%m-%dT%H:%M:%SZ")
+        else:
+            self.updated_at = None
+            
+        create_at_str = data.get('createAt')
+        if create_at_str:
+            self.created_at = datetime.datetime.fromisoformat(create_at_str)
+        else:
+            self.created_at = None
+            
+        self.type = data.get('type')
+        
+        if 'masterId' in data:
+            self.master_id = data['masterId']
+        elif 'master' in data and data['master']:
+            self.master_id = data['master'].get('id')
+        else:
+            self.master_id = None
+            
+        self.share = data.get('share')
+        self.plant_permissions = data.get('plantPermission')
+        self.exist_camera = data.get('existCamera')
+        
+        self.lon = data.get('lon')
+        self.lat = data.get('lat')
+

--- a/sunsynk/plant.py
+++ b/sunsynk/plant.py
@@ -10,38 +10,37 @@ class Plant(Resource):
         self.thumb_url = data.get('thumbUrl')
         self.status = data.get('status')
         self.address = data.get('address')
-        
+
         realtime = data.get('realtime') or {}
         self.pac = data.get('pac') if 'pac' in data else realtime.get('pac')
         self.efficiency = data.get('efficiency') if 'efficiency' in data else realtime.get('efficiency')
         self.generation_today = data.get('etoday') if 'etoday' in data else realtime.get('etoday')
         self.generation_total = data.get('etotal') if 'etotal' in data else realtime.get('etotal')
-        
+
         update_at_str = data.get('updateAt') or realtime.get('updateAt')
         if update_at_str:
             self.updated_at = datetime.datetime.strptime(update_at_str, "%Y-%m-%dT%H:%M:%SZ")
         else:
             self.updated_at = None
-            
+
         create_at_str = data.get('createAt')
         if create_at_str:
             self.created_at = datetime.datetime.fromisoformat(create_at_str)
         else:
             self.created_at = None
-            
+
         self.type = data.get('type')
-        
+
         if 'masterId' in data:
             self.master_id = data['masterId']
         elif 'master' in data and data['master']:
             self.master_id = data['master'].get('id')
         else:
             self.master_id = None
-            
+
         self.share = data.get('share')
         self.plant_permissions = data.get('plantPermission')
         self.exist_camera = data.get('existCamera')
-        
+
         self.lon = data.get('lon')
         self.lat = data.get('lat')
-

--- a/sunsynk/vip_resource.py
+++ b/sunsynk/vip_resource.py
@@ -1,0 +1,20 @@
+from sunsynk.resource import Resource
+
+
+class VipResource(Resource):
+    vip = []
+
+    def get_voltage(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].voltage)
+
+    def get_current(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].current)
+
+    def get_power(self) -> float | None:
+        if len(self.vip) == 0:
+            return None
+        return float(self.vip[0].power)

--- a/sunsynk/weather.py
+++ b/sunsynk/weather.py
@@ -1,0 +1,40 @@
+from sunsynk.resource import Resource
+
+
+class Weather(Resource):
+    def __init__(self, data):
+        curr_wea = data.get('currWea') or {}
+        self.description = curr_wea.get('desc')
+        self.current_temp = curr_wea.get('currTemp')
+        self.wind_speed = curr_wea.get('windSpeed')
+        self.wind_direction = curr_wea.get('windDirection')
+        self.sunrise = curr_wea.get('sunrise')
+        self.sunset = curr_wea.get('sunset')
+        self.icon_url = curr_wea.get('iconUrl')
+        self.temp_min_c = curr_wea.get('tempMinC')
+        self.temp_max_c = curr_wea.get('tempMaxC')
+
+    def get_current_temp(self) -> float | None:
+        if self.current_temp is None:
+            return None
+        return float(self.current_temp)
+
+    def get_wind_speed(self) -> float | None:
+        if self.wind_speed is None:
+            return None
+        return float(self.wind_speed)
+
+    def get_wind_direction(self) -> int | None:
+        if self.wind_direction is None:
+            return None
+        return int(self.wind_direction)
+
+    def get_temp_min_c(self) -> float | None:
+        if self.temp_min_c is None:
+            return None
+        return float(self.temp_min_c)
+
+    def get_temp_max_c(self) -> float | None:
+        if self.temp_max_c is None:
+            return None
+        return float(self.temp_max_c)

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -27,6 +27,9 @@ class MockApiServer:
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/input', self.get_inverter_realtime_input)
         self.app.router.add_get('/api/v1/inverter/1029384756/realtime/output', self.get_inverter_realtime_output)
         self.app.router.add_get('/api/v1/inverter/load/1029384756/realtime', self.get_inverter_realtime_load)
+        self.app.router.add_get('/api/v1/plant/12345', self.get_plant)
+        self.app.router.add_get('/api/v1/weather', self.get_weather)
+
 
     async def client(self, username='myuser'):
         client = await self.aiohttp_client(self.app)
@@ -338,5 +341,113 @@ class MockApiServer:
             'Content-Type': 'application/json'
         }
         return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_plant(self, request):
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "id": 12345,
+                "name": "John Smith",
+                "totalPower": 3.68,
+                "thumbUrl": "https://",
+                "joinDate": "2025-02-20T00:00:00Z",
+                "type": 2,
+                "status": 1,
+                "charges": [
+                    {
+                        "id": 112001545,
+                        "startRange": "00:00",
+                        "endRange": "24:00",
+                        "price": 0.15,
+                        "type": 1,
+                        "stationId": 12345,
+                        "createAt": "2026-03-30T13:13:36Z",
+                        "status": None
+                    }
+                ],
+                "products": None,
+                "lon": -0.724613,
+                "lat": 51.322984,
+                "address": "123 Fake Street",
+                "master": {
+                    "id": 54321,
+                    "nickname": "master@gmail.com",
+                    "mobile": None
+                },
+                "currency": {
+                    "id": 366,
+                    "code": "GBP",
+                    "text": "£"
+                },
+                "timezone": {
+                    "id": 234,
+                    "code": "Europe/London",
+                    "text": "(UTC+00:00)Dublin,Edinburgh,Lisbon,London"
+                },
+                "realtime": {
+                    "pac": 2484,
+                    "efficiency": 0.000,
+                    "etoday": 9.00,
+                    "emonth": 119.40,
+                    "eyear": 1776.50,
+                    "etotal": 5622.30,
+                    "totalPower": 3.68,
+                    "currency": {
+                        "id": 366,
+                        "code": "GBP",
+                        "text": "£"
+                    },
+                    "invest": 8320.00,
+                    "income": 1.3500,
+                    "updateAt": "2026-07-07T12:02:52Z"
+                },
+                "createAt": "2022-10-03T15:39:21.000+00:00",
+                "phone": "01257443377",
+                "email": "",
+                "installer": "",
+                "principal": "Contact Solar",
+                "plantPermission": [
+                    "station.share.cancle"
+                ],
+                "fluxProducts": None,
+                "productWarrantyRegistered": 0,
+                "ctEnable": 1,
+                "invest": 8320.00,
+                "epexProduct": None
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
+    async def get_weather(self, request):
+        lon_lat = request.query.get('lonLat')
+        assert lon_lat == '51.322984,-0.724613'
+        payload = {
+            "code": 0,
+            "msg": "Success",
+            "data": {
+                "currWea": {
+                    "desc": "broken clouds",
+                    "currTemp": "20.6",
+                    "windSpeed": "3.9",
+                    "windDirection": "292",
+                    "sunrise": "04:55",
+                    "sunset": "21:19",
+                    "iconUrl": "https://sunsynk-s3.s3.eu-west-2.amazonaws.com/weather/openweather/04d.png",
+                    "tempMinC": "19.7",
+                    "tempMaxC": "21.8"
+                }
+            },
+            "success": True
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        return web.Response(text=json.dumps(payload), headers=headers)
+
 
 

--- a/tests/mock_api_server.py
+++ b/tests/mock_api_server.py
@@ -30,7 +30,6 @@ class MockApiServer:
         self.app.router.add_get('/api/v1/plant/12345', self.get_plant)
         self.app.router.add_get('/api/v1/weather', self.get_weather)
 
-
     async def client(self, username='myuser'):
         client = await self.aiohttp_client(self.app)
         return await SunsynkClient.create(username, 'letmein', base_url=f'http://{client.host}:{client.port}')
@@ -448,6 +447,3 @@ class MockApiServer:
             'Content-Type': 'application/json'
         }
         return web.Response(text=json.dumps(payload), headers=headers)
-
-
-

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,6 @@ from sunsynk.weather import Weather
 from tests.mock_api_server import MockApiServer
 
 
-
 @pytest.mark.asyncio
 async def test_login(aiohttp_client):
     mock_api_server = MockApiServer(aiohttp_client)
@@ -155,4 +154,15 @@ async def test_get_weather(aiohttp_client):
     assert weather.icon_url == "https://sunsynk-s3.s3.eu-west-2.amazonaws.com/weather/openweather/04d.png"
     assert weather.get_temp_min_c() == 19.7
     assert weather.get_temp_max_c() == 21.8
+
+
+def test_weather_missing_current_conditions():
+    weather = Weather({})
+
+    assert weather.description is None
+    assert weather.get_current_temp() is None
+    assert weather.get_wind_speed() is None
+    assert weather.get_wind_direction() is None
+    assert weather.get_temp_min_c() is None
+    assert weather.get_temp_max_c() is None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,9 @@
 import pytest
 
 from sunsynk.client import SunsynkClient, InvalidCredentialsException
+from sunsynk.weather import Weather
 from tests.mock_api_server import MockApiServer
+
 
 
 @pytest.mark.asyncio
@@ -113,3 +115,44 @@ async def test_get_inverter_realtime_load(aiohttp_client):
     assert load.get_voltage() is None
     assert load.get_current() is None
     assert load.get_power() is None
+
+
+@pytest.mark.asyncio
+async def test_get_plant(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    plant = await client.get_plant(12345)
+
+    assert plant.id == 12345
+    assert plant.name == 'John Smith'
+    assert plant.lon == -0.724613
+    assert plant.lat == 51.322984
+    assert plant.generation_today == 9.00
+    assert plant.generation_total == 5622.30
+    assert plant.pac == 2484
+    assert plant.master_id == 54321
+
+
+@pytest.mark.asyncio
+async def test_get_weather(aiohttp_client):
+    mock_api_server = MockApiServer(aiohttp_client)
+    client = await mock_api_server.client()
+
+    plant = await client.get_plant(12345)
+    lon_lat = f"{plant.lat},{plant.lon}"
+    assert lon_lat == "51.322984,-0.724613"
+
+    weather = await client.get_weather(lon_lat, date="2026-07-07")
+
+    assert isinstance(weather, Weather)
+    assert weather.description == "broken clouds"
+    assert weather.get_current_temp() == 20.6
+    assert weather.get_wind_speed() == 3.9
+    assert weather.get_wind_direction() == 292
+    assert weather.sunrise == "04:55"
+    assert weather.sunset == "21:19"
+    assert weather.icon_url == "https://sunsynk-s3.s3.eu-west-2.amazonaws.com/weather/openweather/04d.png"
+    assert weather.get_temp_min_c() == 19.7
+    assert weather.get_temp_max_c() == 21.8
+


### PR DESCRIPTION
## Summary

Lands the **Weather API + plant-detail/coordinate** work from @benjamingardner's PR #9, plus a follow-up cleanup commit so the package passes the pylint CI gate (`fail-under=10`) and stays in line with existing conventions.

PR #9 was stacked on top of PR #8 (Load, now merged). Squash-merging #8 left #9 in a conflicting state that couldn't be resolved without rewriting the contributor's fork, so #9's weather commit is cherry-picked here (authorship preserved) and this PR **supersedes #9**.

## Commits

1. **`Implement weather API and plant detail coordinate retrieval`** — @benjamingardner's original weather work, unchanged:
   - `get_plant(plant_id)` and `get_weather(lon_lat, date=None, lan='en')` on `SunsynkClient`
   - New `Weather` resource
   - `Plant` extended to parse the single-plant response shape (nested `realtime`, `master`, `lon`/`lat`) while still handling the list response
2. **`Clean up load/weather additions...`** — maintainer follow-up:
   - Extract a shared `VipResource` base for the identical `get_voltage/current/power` accessors on `Grid` and `Load` (resolves the `duplicate-code` pylint failure)
   - Move the `datetime` import in `client.py` to module top-level (`import-outside-toplevel`)
   - Strip trailing whitespace/newline in `plant.py`; tidy stray blank lines
   - Add a `Weather` empty-data test (`weather.py` now 100% covered)
   - Document the three new client methods in the README

## Verification

- `./run-pylint.sh` → **10.00/10**
- `./run-tests.sh` → **12 passed**

## Note for follow-up

`get_weather`'s `lon_lat` argument is passed as `"lat,lon"` (matching Sunsynk's quirky `lonLat` query param, which is lat-first). This matches the observed API behaviour and is now documented in the README, but is worth confirming against the live API.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)